### PR TITLE
Properly extract commit sha from PullRequests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ const program = pipe(
               )
             ),
             TE.orElse(e => {
-              setFailed(e.message);
+              setFailed(`${e.message}\n${e.stack}`);
               return updateGithubCheck(octokit, check, event, [], 'failure', e.message);
             })
           )

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { runSpectral, createSpectral, fileWithContent } from './spectral';
 import { pluralizer } from './utils';
 import { createGithubCheck, createOctokitInstance, getRepositoryInfoFromEvent, updateGithubCheck } from './octokit';
 import glob from 'fast-glob';
-import { error, info, setFailed } from '@actions/core';
+import { info, setFailed } from '@actions/core';
 import * as IOEither from 'fp-ts/lib/IOEither';
 import * as IO from 'fp-ts/lib/IO';
 import * as TE from 'fp-ts/lib/TaskEither';
@@ -187,7 +187,7 @@ program().then(result =>
   pipe(
     result,
     E.fold(
-      e => error(e.message),
+      e => setFailed(`${e.message}\n${e.stack}`),
       () => info('Analysis is complete')
     )
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,12 +147,14 @@ const program = pipe(
               annotations.findIndex(f => f.annotation_level === 'failure') === -1 ? 'success' : 'failure'
             ),
             TE.map(checkResponse => {
-              info(
-                `Check run '${checkResponse.data.name}' concluded with '${checkResponse.data.conclusion}' (${checkResponse.data.html_url})`
-              );
-              info(
-                `Commit ${event.sha} has been annotated (https://github.com/${event.owner}/${event.repo}/commit/${event.sha})`
-              );
+              if (checkResponse !== undefined) {
+                info(
+                  `Check run '${checkResponse.data.name}' concluded with '${checkResponse.data.conclusion}' (${checkResponse.data.html_url})`
+                );
+                info(
+                  `Commit ${event.sha} has been annotated (https://github.com/${event.owner}/${event.repo}/commit/${event.sha})`
+                );
+              }
 
               const fatalErrors = annotations.filter(a => a.annotation_level === 'failure');
               if (fatalErrors.length > 0) {

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -3,6 +3,7 @@ import * as TE from 'fp-ts/lib/TaskEither';
 import * as E from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { ChecksCreateResponse, ChecksUpdateParamsOutputAnnotations, ChecksUpdateParams, Response } from '@octokit/rest';
+import { info } from '@actions/core';
 
 type Event = {
   after: string;
@@ -43,6 +44,7 @@ export const getRepositoryInfoFromEvent = (
   pipe(
     TE.fromEither(E.tryCatch<Error, Event>(() => require(eventPath), E.toError)),
     TE.map(event => {
+      info(`Responding to event '${eventName}'`);
       const { repository, after } = event;
       const {
         owner: { login: owner },

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -1,6 +1,7 @@
 import { getRuleset } from '@stoplight/spectral/dist/cli/services/linter/utils';
 import { isRuleEnabled } from '@stoplight/spectral/dist/runner';
 import { httpAndFileResolver } from '@stoplight/spectral/dist/resolvers/http-and-file';
+import { stylish } from '@stoplight/spectral/dist/formatters/stylish';
 import {
   Spectral,
   isJSONSchema,
@@ -11,6 +12,7 @@ import {
   isJSONSchemaLoose,
   isOpenApiv2,
   isOpenApiv3,
+  IRuleResult,
 } from '@stoplight/spectral';
 
 import * as IOEither from 'fp-ts/lib/IOEither';
@@ -95,12 +97,16 @@ export const createSpectral = (rulesetPath: string) =>
 export type fileWithContent = { path: string; content: string };
 
 export const runSpectral = (spectral: Spectral, fileDescription: fileWithContent) => {
-  return TE.tryCatch(
-    () =>
-      spectral.run(fileDescription.content, {
-        ignoreUnknownFormat: false,
-        resolve: { documentUri: fileDescription.path },
-      }),
-    E.toError
-  );
+  return TE.tryCatch(() => {
+    info(`Linting '${fileDescription.path}'`);
+
+    return spectral.run(fileDescription.content, {
+      ignoreUnknownFormat: false,
+      resolve: { documentUri: fileDescription.path },
+    });
+  }, E.toError);
+};
+
+export const logTextualReport = (results: IRuleResult[]): void => {
+  info(stylish(results));
 };


### PR DESCRIPTION
Fix an issue discovered by @philsturgeon in https://github.com/protect-earth/protect.earth/pull/61/checks?check_run_id=634958740

![image](https://user-images.githubusercontent.com/92363/80804573-e07f4500-8bb5-11ea-9423-d5c0dd9bb472.png)

Also:
- slightly enhance the logging
- run the analysis before attempting to create a checkrun (this will fail when PR is created from a fork as the token isn't granted with enough rights to create annotations), in order to provide minimal feedback.
- re-use Spectral stylish formater to produce a cleaner textual report
- do not fail the action upon insufficient rights (would happen when a PR originates from a fork) => should only fail the build upon fatal linting errors and unexpected errors