### PR TITLE
Support for `useNimma`?

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: |
       The name of the event that triggered the workflow
     default: ${{ github.event_name }}
+  use_nimma:
+    required: false
+    description: Use the experimental JSON Path engine
+    default: 'false'
 runs:
   using: docker
   image: Dockerfile

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ export const Config = D.type({
   INPUT_FILE_GLOB: D.string,
   INPUT_EVENT_NAME: D.string,
   INPUT_SPECTRAL_RULESET: D.string,
+  INPUT_USE_NIMMA: D.bool,
 });
 
 export type Config = D.TypeOf<typeof Config>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,9 @@ import * as path from 'path';
 const CHECK_NAME = 'Lint';
 const traverseTask = array.traverse(T.task);
 
-const createSpectralAnnotations = (ruleset: string, parsed: FileWithContent[], basePath: string) =>
+const createSpectralAnnotations = (ruleset: string, parsed: FileWithContent[], basePath: string, useNimma: boolean) =>
   pipe(
-    createSpectral(ruleset),
+    createSpectral(ruleset, useNimma),
     TE.chain(spectral => {
       const spectralRuns = parsed.map(v =>
         pipe(
@@ -133,7 +133,7 @@ const program = pipe(
   ),
   TE.bind('fileContents', ({ config }) => readFilesToAnalyze(config.INPUT_FILE_GLOB, config.GITHUB_WORKSPACE)),
   TE.bind('annotations', ({ fileContents, config }) =>
-    createSpectralAnnotations(config.INPUT_SPECTRAL_RULESET, fileContents, config.GITHUB_WORKSPACE)
+    createSpectralAnnotations(config.INPUT_SPECTRAL_RULESET, fileContents, config.GITHUB_WORKSPACE, config.INPUT_USE_NIMMA)
   ),
   TE.bind('checkResponse', ({ octokit, check, repositoryInfo, annotations }) =>
     updateGithubCheck(

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -52,14 +52,14 @@ const retrieveSpectralPackageVersion = (): IOEither.IOEither<Error, string> =>
     return String(x.version);
   }, E.toError);
 
-export const createSpectral = (rulesetPath: string) =>
+export const createSpectral = (rulesetPath: string, useNimma: boolean) =>
   pipe(
     TE.fromIOEither(retrieveSpectralPackageVersion()),
     TE.chain(spectralPackageVersion =>
       TE.tryCatch(async () => {
         info(`Running Spectral v${spectralPackageVersion}`);
 
-        const spectral = new Spectral({ resolver: httpAndFileResolver });
+        const spectral = new Spectral({ resolver: httpAndFileResolver, useNimma: useNimma });
         spectral.registerFormat('oas2', isOpenApiv2);
         spectral.registerFormat('oas3', isOpenApiv3);
         spectral.registerFormat('json-schema', isJSONSchema);


### PR DESCRIPTION
Would it be possible to have a config to enable `useNimma` through this GitHub action?

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

We're having issues with https://github.com/stoplightio/spectral/issues/1223 and it would be nice to be able to use this action as is.

Opened this PR for conversation but feel free to let me know how best to support this 👍 