### PR TITLE
chore: adapt README to latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Run Spectral
-      - uses: stoplightio/spectral-action@v0.7.0
+      - uses: stoplightio/spectral-action@v0.7.2
         with:
           file_glob: 'doc/api/*.yaml'
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Run Spectral
-      - uses: stoplightio/spectral-action@v0.5.5
+      - uses: stoplightio/spectral-action@v0.7.0
         with:
           file_glob: 'doc/api/*.yaml'
 ```


### PR DESCRIPTION
Update the release tag in the example from v0.5.5 to v0.7.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stoplightio/spectral-action/472)
<!-- Reviewable:end -->
