### PR TITLE
fix: handle no annotations in updateGithubCheck

### DIFF
--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -118,7 +118,7 @@ export const updateGithubCheck = (
   conclusion: Conclusions,
   message?: string
 ) => {
-  const chunkedAnnotations = chunk(annotations.length ? annotations : []);
+  const chunkedAnnotations = annotations.length ? chunk(annotations) : [[]];
 
   const updateAttempts = chunkedAnnotations.map(annotationChunk =>
     TE.tryCatch(

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -118,7 +118,7 @@ export const updateGithubCheck = (
   conclusion: Conclusions,
   message?: string
 ) => {
-  const chunkedAnnotations = chunk(annotations);
+  const chunkedAnnotations = chunk(annotations.length ? annotations : []);
 
   const updateAttempts = chunkedAnnotations.map(annotationChunk =>
     TE.tryCatch(


### PR DESCRIPTION
For #506 

If there are no annotations, `octokit.checks.update` is never called and it remains in progress.