### PR TITLE
Updated info related to spectral_ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,4 @@ jobs:
 ### Inputs
 
 - **file_glob:** Pattern describing the set of files to lint. Defaults to `*.oas.{json,yml,yaml}`. (_Note:_ Pattern syntax is documented in the [fast-glob](https://www.npmjs.com/package/fast-glob) package documentation)
-- **spectral_ruleset:** Custom ruleset to load in Spectral. When unspecified, will try to load the default `.spectral.yaml` ruleset if it exists; otherwise, the default built-in Spectral rulesets will be loaded.
-
-## Configuration
-
-Spectral Action will respect your [Spectral Rulesets](https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/getting-started/rulesets.md), which can be defined, extended, and overriden by placing `.spectral.yml` in the root of your repository.
+- **spectral_ruleset:** Ruleset to be used by Spectral. When unspecified, will try to load then from `.spectral.yaml` in the root of your repository.


### PR DESCRIPTION
If you do not have a `.spectral.yaml` in the root of the project `spectral_ruleset` must be set. There is no such a thing as `the default built-in Spectral rulesets`.

Please note that this has changed with version `0.8.0` of the action since it uses version 6 of Spectral that changed the ruleset behavior https://github.com/stoplightio/spectral/issues/1796

I think that also the `Configuration` section should be removed because is just a repetition.