### PR TITLE
Build, deploy and then use prebuilt docker image

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,0 +1,50 @@
+name: Build & Deploy Container 
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  workflow_dispatch: {}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Log in to Github Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     default: ${{ github.event_name }}
 runs:
   using: docker
-  image: Dockerfile
+  image: 'docker://ghcr.io/stoplightio/spectral-action:0.8.3'
 branding:
   icon: code
   color: yellow


### PR DESCRIPTION
This relates to https://github.com/stoplightio/spectral-action/issues/452.

With these changes, once a PR is merged to `master` or a tag is added (e.g. `v0.8.3`), the new `container-build.yml` workflow will run. This will then build some metadata for the image, login to Github Container Registry, and then build/push the package. The package will appear [here](https://github.com/orgs/stoplightio/packages). You can see an example of how it would look on my fork [here](https://github.com/carlreid/spectral-action/pkgs/container/spectral-action).

Then the action will now load the image from this public registry path:
`image: 'docker://ghcr.io/stoplightio/spectral-action:0.8.3'`

It makes use of the public registry using the syntax described [here](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#example-using-public-docker-registry-container) and [here](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsuses) (this is gcr, we will use g**h**cr).

You can see the CI test passing and pulling the image as expected [here](https://github.com/carlreid/spectral-action/runs/4268764811?check_suite_focus=true#step:3:8).

**Note:** You will need to add a secret to this repository called `CR_PAT` which has the `write:packages` permission from a Personal Access Token (aka PAT). It will needs to be created [here](https://github.com/settings/tokens).