### PR TITLE
Fix installing node-prune 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ ENV NODE_ENV production
 COPY package.json yarn.lock ./
 RUN yarn --production
 
-RUN curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | bash
-RUN ./bin/node-prune
+RUN curl -sf https://gobinaries.com/tj/node-prune | sh
+RUN node-prune
 
 ###############################################################
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
Docker builds failed with current master branch.

```sh
➜ docker build .
[+] Building 2.4s (18/19)
 => [internal] load build definition from Dockerfile                                                                                                                                                             0.0s
 => => transferring dockerfile: 764B                                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                0.0s
 => => transferring context: 34B                                                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/node:14-alpine                                                                                                                                                2.2s
 => [internal] load metadata for docker.io/library/node:14                                                                                                                                                       2.2s
 => [internal] load build context                                                                                                                                                                                0.0s
 => => transferring context: 15.69kB                                                                                                                                                                             0.0s
 => [builder 1/7] FROM docker.io/library/node:14@sha256:42353ba2f129758dd5df19c6bcc3107d519436585467b231883b07f21336a484                                                                                         0.0s
 => [runtime 1/4] FROM docker.io/library/node:14-alpine@sha256:c9b8829068199346e2a9ae46f870bbb82ce44de6580321300bf3945d00dee0f1                                                                                  0.0s
 => CACHED [runtime 2/4] COPY package.json /action/package.json                                                                                                                                                  0.0s
 => CACHED [builder 2/7] COPY package.json yarn.lock ./                                                                                                                                                          0.0s
 => CACHED [builder 3/7] RUN yarn                                                                                                                                                                                0.0s
 => CACHED [builder 4/7] COPY src ./src                                                                                                                                                                          0.0s
 => CACHED [builder 5/7] COPY tsconfig.json tsconfig.json                                                                                                                                                        0.0s
 => CACHED [builder 6/7] RUN yarn                                                                                                                                                                                0.0s
 => CACHED [builder 7/7] RUN yarn build                                                                                                                                                                          0.0s
 => CACHED [runtime 3/4] COPY --from=builder dist /action/dist                                                                                                                                                   0.0s
 => CACHED [dependencies 3/5] RUN yarn --production                                                                                                                                                              0.0s
 => CACHED [dependencies 4/5] RUN curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | bash                                                                                                    0.0s
 => ERROR [dependencies 5/5] RUN ./bin/node-prune                                                                                                                                                                0.1s
------
 > [dependencies 5/5] RUN ./bin/node-prune:
#18 0.132 /bin/sh: 1: ./bin/node-prune: not found
------
executor failed running [/bin/sh -c ./bin/node-prune]: exit code: 127
```

It's because `install.goreleaser.com` has gone.

```
➜ curl install.goreleaser.com
curl: (6) Could not resolve host: install.goreleaser.com

```

#InsertIssueNumberHere
none

## Description
Update node-prune installing way.
I used the way described in https://github.com/tj/node-prune/blob/master/Readme.md


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->

With this PR, doker build success
```
➜ docker build . --no-cache
[+] Building 23.2s (20/20) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                             0.0s
 => => transferring dockerfile: 37B                                                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                                                0.0s
 => => transferring context: 34B                                                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/node:14-alpine                                                                                                                                                1.2s
 => [internal] load metadata for docker.io/library/node:14                                                                                                                                                       1.2s
 => [internal] load build context                                                                                                                                                                                0.0s
 => => transferring context: 365B                                                                                                                                                                                0.0s
 => CACHED [runtime 1/4] FROM docker.io/library/node:14-alpine@sha256:c9b8829068199346e2a9ae46f870bbb82ce44de6580321300bf3945d00dee0f1                                                                           0.0s
 => CACHED [dependencies 1/5] FROM docker.io/library/node:14@sha256:42353ba2f129758dd5df19c6bcc3107d519436585467b231883b07f21336a484                                                                             0.0s
 => [dependencies 2/5] COPY package.json yarn.lock ./                                                                                                                                                            0.0s
 => [runtime 2/4] COPY package.json /action/package.json                                                                                                                                                         0.0s
 => [builder 3/7] RUN yarn                                                                                                                                                                                      12.7s
 => [dependencies 3/5] RUN yarn --production                                                                                                                                                                    18.5s
 => [builder 4/7] COPY src ./src                                                                                                                                                                                 0.0s
 => [builder 5/7] COPY tsconfig.json tsconfig.json                                                                                                                                                               0.0s
 => [builder 6/7] RUN yarn                                                                                                                                                                                       0.4s
 => [builder 7/7] RUN yarn build                                                                                                                                                                                 1.9s
 => [runtime 3/4] COPY --from=builder dist /action/dist                                                                                                                                                          0.0s
 => [dependencies 4/5] RUN curl -sf https://gobinaries.com/tj/node-prune | sh                                                                                                                                    2.1s
 => [dependencies 5/5] RUN node-prune                                                                                                                                                                            0.4s
 => [runtime 4/4] COPY --from=dependencies node_modules /action/node_modules                                                                                                                                     0.2s
 => exporting to image                                                                                                                                                                                           0.1s
 => => exporting layers                                                                                                                                                                                          0.1s
 => => writing image sha256:e8fcd82f602a5e3aee84af905c1e4a819ffe5a99cfd337ce0a2b35ab882c07e0                                                                                                                     0.0s

```
