### PR TITLE
Update README.md to represent current ruleset default behavior (and fix broken link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ jobs:
 ### Inputs
 
 - **file_glob:** Pattern describing the set of files to lint. Defaults to `*.oas.{json,yml,yaml}`. (_Note:_ Pattern syntax is documented in the [fast-glob](https://www.npmjs.com/package/fast-glob) package documentation)
-- **spectral_ruleset:** Custom ruleset to load in Spectral. When unspecified, will try to load the default `.spectral.yaml` ruleset if it exists; otherwise, the default built-in Spectral rulesets will be loaded.
+- **spectral_ruleset:** Custom ruleset to load in Spectral. When unspecified, will try to load the default `.spectral.yaml` ruleset if it exists.
 
 ## Configuration
 
 Spectral Action will respect your [Spectral Rulesets](https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/getting-started/rulesets.md), which can be defined, extended, and overriden by placing `.spectral.yml` in the root of your repository.
+
+However, if you'd like to simply use a core ruleset without additional configuration, create a `.spectral.yml` in you repository's root with only the contents:
+
+> extends: ["spectral:{rulesetTagHere}"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
 
 ## Configuration
 
-Spectral Action will respect your [Spectral Rulesets](https://stoplight.io/p/docs/gh/stoplightio/spectral/docs/getting-started/rulesets.md), which can be defined, extended, and overriden by placing `.spectral.yml` in the root of your repository.
+Spectral Action will respect your [Spectral Rulesets](https://meta.stoplight.io/docs/spectral/01baf06bdd05a-rulesets), which can be defined, extended, and overriden by placing `.spectral.yml` in the root of your repository.
 
 However, if you'd like to simply use a core ruleset without additional configuration, create a `.spectral.yml` in you repository's root with only the contents:
 


### PR DESCRIPTION
In the upgrade to v0.6~ it looks like default behavior  -- to use a built-in/core ruleset in the case that no ruleset spec exists in the user's Github workspace -- was either broken or purposefully removed. This PR just updates the README to represent the current functionality.

(ALSO) fixes a broken link to the Spectral Rulesets page.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
The README makes it sound like you can avoid specifying or creating a local spec for your ruleset when using
spectral-action in your CI. That is no longer the case!
<!-- If it fixes an open issue, please link to the issue here. -->
#635

## Description
Update the README to both:
a) Stop indicating that spectral-action will use a core ruleset if none exist locally
b) Provide a simple ruleset setup example for users who want to simply use a core ruleset.


## How Has This Been Tested?
It's just a readme update!
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->


## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
N/A

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
N/A
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
