### PR TITLE
Allow new github event type i.e `pull_request_target`

### DIFF
--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -72,6 +72,7 @@ export interface RepositoryInfo {
 const extractSha = (eventName: string, event: any): E.Either<Error, string> => {
   switch (eventName) {
     case 'pull_request':
+    case 'pull_request_target':
       return E.right(event.pull_request ? event.pull_request.head.sha : event.after);
     case 'push':
       return E.right(event.after);


### PR DESCRIPTION

## Motivation and Context
This feature will allow users to run spectral-action when github action event type is `pull_request_target`

## Description
Added fall through case for event type `pull_request_target`

## Screenshot(s)/recordings(s)
<img width="502" alt="image" src="https://github.com/stoplightio/spectral-action/assets/33805661/316ce6e3-34ef-47db-be2c-60453bc6bb11">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
